### PR TITLE
Build assert (__assert_func).

### DIFF
--- a/newlib/libc/stdlib/Makefile.am
+++ b/newlib/libc/stdlib/Makefile.am
@@ -6,6 +6,7 @@ INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
 
 GENERAL_SOURCES = \
 	abs.c 		\
+	assert.c	\
 	atof.c 		\
 	atoff.c		\
 	atoi.c  	\

--- a/newlib/libc/stdlib/Makefile.in
+++ b/newlib/libc/stdlib/Makefile.in
@@ -82,16 +82,16 @@ am__DEPENDENCIES_1 =
 @ELIX_LEVEL_1_FALSE@@ELIX_LEVEL_2_TRUE@	$(am__DEPENDENCIES_1)
 @HAVE_LONG_DOUBLE_TRUE@am__objects_1 = lib_a-strtold.$(OBJEXT) \
 @HAVE_LONG_DOUBLE_TRUE@	lib_a-wcstold.$(OBJEXT)
-am__objects_2 = lib_a-abs.$(OBJEXT) lib_a-atof.$(OBJEXT) \
-	lib_a-atoff.$(OBJEXT) lib_a-atoi.$(OBJEXT) \
-	lib_a-atol.$(OBJEXT) lib_a-div.$(OBJEXT) lib_a-dtoa.$(OBJEXT) \
-	lib_a-dtoastub.$(OBJEXT) lib_a-gdtoa-gethex.$(OBJEXT) \
-	lib_a-gdtoa-hexnan.$(OBJEXT) lib_a-labs.$(OBJEXT) \
-	lib_a-ldiv.$(OBJEXT) lib_a-ldtoa.$(OBJEXT) \
-	lib_a-mprec.$(OBJEXT) lib_a-rand.$(OBJEXT) \
-	lib_a-rand_r.$(OBJEXT) lib_a-strtod.$(OBJEXT) \
-	lib_a-strtol.$(OBJEXT) lib_a-strtoul.$(OBJEXT) \
-	$(am__objects_1)
+am__objects_2 = lib_a-abs.$(OBJEXT) lib_a-assert.$(OBJEXT) \
+	lib_a-atof.$(OBJEXT) lib_a-atoff.$(OBJEXT) \
+	lib_a-atoi.$(OBJEXT) lib_a-atol.$(OBJEXT) lib_a-div.$(OBJEXT) \
+	lib_a-dtoa.$(OBJEXT) lib_a-dtoastub.$(OBJEXT) \
+	lib_a-gdtoa-gethex.$(OBJEXT) lib_a-gdtoa-hexnan.$(OBJEXT) \
+	lib_a-labs.$(OBJEXT) lib_a-ldiv.$(OBJEXT) \
+	lib_a-ldtoa.$(OBJEXT) lib_a-mprec.$(OBJEXT) \
+	lib_a-rand.$(OBJEXT) lib_a-rand_r.$(OBJEXT) \
+	lib_a-strtod.$(OBJEXT) lib_a-strtol.$(OBJEXT) \
+	lib_a-strtoul.$(OBJEXT) $(am__objects_1)
 am__objects_3 = lib_a-drand48.$(OBJEXT) lib_a-ecvtbuf.$(OBJEXT) \
 	lib_a-efgcvt.$(OBJEXT) lib_a-erand48.$(OBJEXT) \
 	lib_a-jrand48.$(OBJEXT) lib_a-lcong48.$(OBJEXT) \
@@ -117,10 +117,10 @@ am__objects_5 =
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 LTLIBRARIES = $(noinst_LTLIBRARIES)
 @HAVE_LONG_DOUBLE_TRUE@am__objects_7 = strtold.lo wcstold.lo
-am__objects_8 = abs.lo atof.lo atoff.lo atoi.lo atol.lo div.lo dtoa.lo \
-	dtoastub.lo gdtoa-gethex.lo gdtoa-hexnan.lo labs.lo ldiv.lo \
-	ldtoa.lo mprec.lo rand.lo rand_r.lo strtod.lo strtol.lo \
-	strtoul.lo $(am__objects_7)
+am__objects_8 = abs.lo assert.lo atof.lo atoff.lo atoi.lo atol.lo \
+	div.lo dtoa.lo dtoastub.lo gdtoa-gethex.lo gdtoa-hexnan.lo \
+	labs.lo ldiv.lo ldtoa.lo mprec.lo rand.lo rand_r.lo strtod.lo \
+	strtol.lo strtoul.lo $(am__objects_7)
 am__objects_9 = drand48.lo ecvtbuf.lo efgcvt.lo erand48.lo jrand48.lo \
 	lcong48.lo lrand48.lo mrand48.lo nrand48.lo rand48.lo \
 	seed48.lo srand48.lo strtoll.lo strtoll_r.lo strtoull.lo \
@@ -307,9 +307,9 @@ top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 AUTOMAKE_OPTIONS = cygnus
 INCLUDES = $(NEWLIB_CFLAGS) $(CROSS_CFLAGS) $(TARGET_CFLAGS)
-GENERAL_SOURCES = abs.c atof.c atoff.c atoi.c atol.c div.c dtoa.c \
-	dtoastub.c gdtoa-gethex.c gdtoa-hexnan.c labs.c ldiv.c ldtoa.c \
-	mprec.c rand.c rand_r.c strtod.c strtol.c strtoul.c \
+GENERAL_SOURCES = abs.c assert.c atof.c atoff.c atoi.c atol.c div.c \
+	dtoa.c dtoastub.c gdtoa-gethex.c gdtoa-hexnan.c labs.c ldiv.c \
+	ldtoa.c mprec.c rand.c rand_r.c strtod.c strtol.c strtoul.c \
 	$(am__append_1)
 @NEWLIB_NANO_MALLOC_FALSE@MALIGNR = malignr
 @NEWLIB_NANO_MALLOC_TRUE@MALIGNR = nano-malignr
@@ -513,6 +513,12 @@ lib_a-abs.o: abs.c
 
 lib_a-abs.obj: abs.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-abs.obj `if test -f 'abs.c'; then $(CYGPATH_W) 'abs.c'; else $(CYGPATH_W) '$(srcdir)/abs.c'; fi`
+
+lib_a-assert.o: assert.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-assert.o `test -f 'assert.c' || echo '$(srcdir)/'`assert.c
+
+lib_a-assert.obj: assert.c
+	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-assert.obj `if test -f 'assert.c'; then $(CYGPATH_W) 'assert.c'; else $(CYGPATH_W) '$(srcdir)/assert.c'; fi`
 
 lib_a-atof.o: atof.c
 	$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CFLAGS) $(CFLAGS) -c -o lib_a-atof.o `test -f 'atof.c' || echo '$(srcdir)/'`atof.c

--- a/newlib/libc/stdlib/assert.c
+++ b/newlib/libc/stdlib/assert.c
@@ -56,10 +56,12 @@ _DEFUN (__assert_func, (file, line, func, failedexpr),
 	const char *func _AND
 	const char *failedexpr)
 {
+#ifndef __nvptx__
   fiprintf(stderr,
 	   "assertion \"%s\" failed: file \"%s\", line %d%s%s\n",
 	   failedexpr, file, line,
 	   func ? ", function: " : "", func ? func : "");
+#endif
   abort();
   /* NOTREACHED */
 }


### PR DESCRIPTION
Based on GCC trunk r220892:

```
                === gcc Summary ===

# of expected passes            [-69258-]{+69290+}
# of unexpected failures        [-1606-]{+1590+}
# of unexpected successes       3
# of expected failures          130
# of unresolved testcases       [-507-]{+491+}
# of unsupported tests          3146

                === gfortran Summary ===

# of expected passes            [-31240-]{+31320+}
# of unexpected failures        7222
# of expected failures          78
# of unresolved testcases       [-6489-]{+6441+}
# of untested testcases         432
# of unsupported tests          639
```

No change for g++.

gcc:

```
[-FAIL:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -O0  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -O0  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.c-torture/execute/pr58831.c   -O1  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -O1  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.c-torture/execute/pr58831.c   -O2  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -O2  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.c-torture/execute/pr58831.c   -O3 -fomit-frame-pointer  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -O3 -fomit-frame-pointer  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.c-torture/execute/pr58831.c   -O3 -fomit-frame-pointer -funroll-loops  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -O3 -fomit-frame-pointer -funroll-loops  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.c-torture/execute/pr58831.c   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.c-torture/execute/pr58831.c   -O3 -g  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -O3 -g  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.c-torture/execute/pr58831.c   -Os  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.c-torture/execute/pr58831.c   -Os  [-compilation failed to produce executable-]{+execution test+}

[-FAIL:-]{+PASS:+} gcc.dg/cpp/builtin-macro-1.c (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.dg/cpp/builtin-macro-1.c [-compilation failed to produce executable-]{+execution test+}

[-FAIL:-]{+PASS:+} gcc.dg/pr64007.c (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.dg/pr64007.c [-compilation failed to produce executable-]{+execution test+}

[-FAIL:-]{+PASS:+} gcc.dg/torture/pr51244-21.c   -O0  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.dg/torture/pr51244-21.c   -O0  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.dg/torture/pr51244-21.c   -O1  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.dg/torture/pr51244-21.c   -O1  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.dg/torture/pr51244-21.c   -O2  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.dg/torture/pr51244-21.c   -O2  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.dg/torture/pr51244-21.c   -O3 -fomit-frame-pointer  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.dg/torture/pr51244-21.c   -O3 -fomit-frame-pointer  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.dg/torture/pr51244-21.c   -O3 -g  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.dg/torture/pr51244-21.c   -O3 -g  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gcc.dg/torture/pr51244-21.c   -Os  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gcc.dg/torture/pr51244-21.c   -Os  [-compilation failed to produce executable-]{+execution test+}
```

gfortran:

```
[-FAIL:-]{+PASS:+} gfortran.dg/matmul_1.f90   -O0  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/matmul_1.f90   -O0  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/matmul_1.f90   -O1  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/matmul_1.f90   -O1  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/matmul_1.f90   -O2  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/matmul_1.f90   -O2  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/matmul_1.f90   -O3 -fomit-frame-pointer  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/matmul_1.f90   -O3 -fomit-frame-pointer  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/matmul_1.f90   -O3 -fomit-frame-pointer -funroll-loops  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/matmul_1.f90   -O3 -fomit-frame-pointer -funroll-loops  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/matmul_1.f90   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/matmul_1.f90   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/matmul_1.f90   -O3 -g  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/matmul_1.f90   -O3 -g  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/matmul_1.f90   -Os  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/matmul_1.f90   -Os  [-compilation failed to produce executable-]{+execution test+}

[-FAIL:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -O0  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -O0  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_2.f90   {+-O0  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 18832', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 2: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_2.f90+}   -O1  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -O1  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_2.f90   {+-O1  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 11354', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 2: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_2.f90+}   -O2  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -O2  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_2.f90   {+-O2  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 2: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_2.f90+}   -O3 -fomit-frame-pointer  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -O3 -fomit-frame-pointer  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_2.f90   -O3 -fomit-frame-pointer  {+output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 2: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_2.f90   -O3 -fomit-frame-pointer+} -funroll-loops  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -O3 -fomit-frame-pointer -funroll-loops  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_2.f90   -O3 -fomit-frame-pointer {+-funroll-loops  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 2: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_2.f90   -O3 -fomit-frame-pointer+} -funroll-all-loops -finline-functions  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_2.f90   -O3 {+-fomit-frame-pointer -funroll-all-loops -finline-functions  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 2: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_2.f90   -O3+} -g  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -O3 -g  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_2.f90   {+-O3 -g  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 2: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_2.f90+}   -Os  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_2.f90   -Os  [-compilation failed to produce executable-]{+execution test+}
FAIL: {+gfortran.dg/matmul_bounds_2.f90   -Os  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 2: is 2, should be 3+}
{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -O0  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -O0  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_3.f90   {+-O0  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 18832', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 1: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_3.f90+}   -O1  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -O1  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_3.f90   {+-O1  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 11354', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 1: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_3.f90+}   -O2  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -O2  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_3.f90   {+-O2  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 1: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_3.f90+}   -O3 -fomit-frame-pointer  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -O3 -fomit-frame-pointer  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_3.f90   -O3 -fomit-frame-pointer  {+output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 1: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_3.f90   -O3 -fomit-frame-pointer+} -funroll-loops  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -O3 -fomit-frame-pointer -funroll-loops  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_3.f90   -O3 -fomit-frame-pointer {+-funroll-loops  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 1: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_3.f90   -O3 -fomit-frame-pointer+} -funroll-all-loops -finline-functions  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_3.f90   -O3 {+-fomit-frame-pointer -funroll-all-loops -finline-functions  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 1: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_3.f90   -O3+} -g  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -O3 -g  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_3.f90   {+-O3 -g  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 1: is 2, should be 3+}
{+PASS: gfortran.dg/matmul_bounds_3.f90+}   -Os  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_3.f90   -Os  [-compilation failed to produce executable-]{+execution test+}
FAIL: {+gfortran.dg/matmul_bounds_3.f90   -Os  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10461', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic for dimension 1: is 2, should be 3+}
{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -O0  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -O0  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_4.f90   {+-O0  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 17790', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_4.f90+}   -O1  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -O1  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_4.f90   {+-O1  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 11017', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_4.f90+}   -O2  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -O2  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_4.f90   {+-O2  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_4.f90+}   -O3 -fomit-frame-pointer  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -O3 -fomit-frame-pointer  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_4.f90   -O3 -fomit-frame-pointer  {+output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_4.f90   -O3 -fomit-frame-pointer+} -funroll-loops  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -O3 -fomit-frame-pointer -funroll-loops  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_4.f90   -O3 -fomit-frame-pointer {+-funroll-loops  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_4.f90   -O3 -fomit-frame-pointer+} -funroll-all-loops -finline-functions  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_4.f90   -O3 {+-fomit-frame-pointer -funroll-all-loops -finline-functions  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_4.f90   -O3+} -g  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -O3 -g  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_4.f90   {+-O3 -g  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_4.f90+}   -Os  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_4.f90   -Os  [-compilation failed to produce executable-]{+execution test+}
FAIL: {+gfortran.dg/matmul_bounds_4.f90   -Os  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -O0  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -O0  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_5.f90   {+-O0  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 17728', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_5.f90+}   -O1  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -O1  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_5.f90   {+-O1  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 11011', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_5.f90+}   -O2  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -O2  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_5.f90   {+-O2  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_5.f90+}   -O3 -fomit-frame-pointer  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -O3 -fomit-frame-pointer  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_5.f90   -O3 -fomit-frame-pointer  {+output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_5.f90   -O3 -fomit-frame-pointer+} -funroll-loops  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -O3 -fomit-frame-pointer -funroll-loops  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_5.f90   -O3 -fomit-frame-pointer {+-funroll-loops  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_5.f90   -O3 -fomit-frame-pointer+} -funroll-all-loops -finline-functions  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_5.f90   -O3 {+-fomit-frame-pointer -funroll-all-loops -finline-functions  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_5.f90   -O3+} -g  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -O3 -g  [-compilation failed to produce executable-]{+execution test+}
FAIL: gfortran.dg/matmul_bounds_5.f90   {+-O3 -g  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}
{+PASS: gfortran.dg/matmul_bounds_5.f90+}   -Os  (test for excess errors)
[-UNRESOLVED:-]{+PASS:+} gfortran.dg/matmul_bounds_5.f90   -Os  [-compilation failed to produce executable-]{+execution test+}
{+FAIL: gfortran.dg/matmul_bounds_5.f90   -Os  output pattern test, is error   : Prototype doesn't match for '_gfortran_matmul_r4' in 'input file 3 at offset 10101', first defined in 'input file 1 at offset 1091'+}
{+nvptx-run: cuLinkAddData failed: [unknown] ([unknown], 999)+}
{+, should match Fortran runtime error: Incorrect extent in return array in MATMUL intrinsic: is 3, should be 2+}

[-FAIL:-]{+PASS:+} gfortran.dg/realloc_on_assign_11.f90   -O0  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/realloc_on_assign_11.f90   -O0  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/realloc_on_assign_11.f90   -O1  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/realloc_on_assign_11.f90   -O1  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/realloc_on_assign_11.f90   -O2  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/realloc_on_assign_11.f90   -O2  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/realloc_on_assign_11.f90   -O3 -fomit-frame-pointer  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/realloc_on_assign_11.f90   -O3 -fomit-frame-pointer  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/realloc_on_assign_11.f90   -O3 -fomit-frame-pointer -funroll-loops  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/realloc_on_assign_11.f90   -O3 -fomit-frame-pointer -funroll-loops  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/realloc_on_assign_11.f90   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/realloc_on_assign_11.f90   -O3 -fomit-frame-pointer -funroll-all-loops -finline-functions  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/realloc_on_assign_11.f90   -O3 -g  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/realloc_on_assign_11.f90   -O3 -g  [-compilation failed to produce executable-]
[-FAIL:-]{+execution test+}
{+PASS:+} gfortran.dg/realloc_on_assign_11.f90   -Os  (test for excess errors)
[-UNRESOLVED:-]{+FAIL:+} gfortran.dg/realloc_on_assign_11.f90   -Os  [-compilation failed to produce executable-]{+execution test+}
```
