### PR TITLE
nvptx "abort" implementation: "trap" instead of "exit"

### DIFF
--- a/newlib/libc/machine/nvptx/abort.c
+++ b/newlib/libc/machine/nvptx/abort.c
@@ -1,6 +1,6 @@
 /*
  * Support file for nvptx in newlib.
- * Copyright (c) 2014-2016 Mentor Graphics.
+ * Copyright (c) 2014-2017 Mentor Graphics.
  *
  * The authors hereby grant permission to use, copy, modify, distribute,
  * and license this software and its documentation for any purpose, provided
@@ -18,8 +18,6 @@
 void __attribute__((noreturn))
 abort (void)
 {
-  /* If anybody cared about the exit code, they should have set it to
-     non-zero in crt0.  */
   for (;;)
-    asm ("exit;" ::: "memory");
+    __builtin_trap ();
 }


### PR DESCRIPTION
Fixes #5.